### PR TITLE
Add logData check before logFile.write call

### DIFF
--- a/PyOLabCode/commMethods.py
+++ b/PyOLabCode/commMethods.py
@@ -37,7 +37,8 @@ def getIOLabPortName():
     pList = []
     for port in ports:
          pInfo = list(port)
-         G.logFile.write("\npInfo: "+str(pInfo))
+         if G.logData:
+            G.logFile.write("\npInfo: "+str(pInfo))
          if 'IOLab' in pInfo[1] or 'PID=1881' in pInfo[2]:
             pList.append(pInfo)
 


### PR DESCRIPTION
There was a `G.logFile.write` command without a `G.logFile` check which causes an error when `G.logFile` is set to False.